### PR TITLE
Add basic config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Many types are excluded by default, as they're collected by framework magic, e.g
 ```bash
 vendor/bin/class-leak check bin src --skip-type="App\\Contract\\SomeInterface"
 ```
+
+It is also possible to specify the skipped types via a configuration file:
+
+```bash
+vendor/bin/class-leak check bin src -c class-leak.yaml
+```
+
+With this YAML as `class-leak.yaml` content:
+
+```yaml
+typesToSkip:
+    - App\Contract\SomeInterface
+```

--- a/app/Console/Commands/CheckCommand.php
+++ b/app/Console/Commands/CheckCommand.php
@@ -112,11 +112,22 @@ final class CheckCommand extends Command
      */
     private static function resolveTypesToSkip(InputInterface $input): array
     {
-        /** @var string[] $typesToSkip */
-        $typesToSkip = [];
+        $config = null;
 
         if ($input->getOption('configuration') !== null) {
             $config = Yaml::parseFile($input->getOption('configuration'));
+        }
+
+        $defaultConfigFileName = getcwd() . '/class-leak.yaml';
+
+        if ($config === null && file_exists($defaultConfigFileName)) {
+            $config = Yaml::parseFile($defaultConfigFileName);
+        }
+
+        /** @var string[] $typesToSkip */
+        $typesToSkip = [];
+
+        if ($config !== null) {
             $typesToSkip = $config['typesToSkip'] ?? [];
         }
 

--- a/app/Console/Commands/CheckCommand.php
+++ b/app/Console/Commands/CheckCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
 use TomasVotruba\ClassLeak\Filtering\PossiblyUnusedClassesFilter;
 use TomasVotruba\ClassLeak\Finder\ClassNamesFinder;
 use TomasVotruba\ClassLeak\Finder\PhpFilesFinder;
@@ -46,6 +47,12 @@ final class CheckCommand extends Command
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
             'Class types that should be skipped'
         );
+        $this->addOption(
+            'configuration',
+            'c',
+            InputOption::VALUE_REQUIRED,
+            'Configuration file name'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -54,7 +61,16 @@ final class CheckCommand extends Command
         $paths = (array) $input->getArgument('paths');
 
         /** @var string[] $typesToSkip */
-        $typesToSkip = (array) $input->getOption('skip-type');
+        $typesToSkip = [];
+
+        if ($input->getOption('configuration') !== null) {
+            $config = Yaml::parseFile($input->getOption('configuration'));
+            $typesToSkip = $config['typesToSkip'] ?? [];
+        }
+
+        if (count($input->getOption('skip-type')) > 0) {
+            $typesToSkip = (array)$input->getOption('skip-type');
+        }
 
         $phpFilePaths = $this->phpFilesFinder->findPhpFiles($paths);
 

--- a/app/Console/Commands/CheckCommand.php
+++ b/app/Console/Commands/CheckCommand.php
@@ -60,17 +60,7 @@ final class CheckCommand extends Command
         /** @var string[] $paths */
         $paths = (array) $input->getArgument('paths');
 
-        /** @var string[] $typesToSkip */
-        $typesToSkip = [];
-
-        if ($input->getOption('configuration') !== null) {
-            $config = Yaml::parseFile($input->getOption('configuration'));
-            $typesToSkip = $config['typesToSkip'] ?? [];
-        }
-
-        if (count($input->getOption('skip-type')) > 0) {
-            $typesToSkip = (array)$input->getOption('skip-type');
-        }
+        $typesToSkip = self::resolveTypesToSkip($input);
 
         $phpFilePaths = $this->phpFilesFinder->findPhpFiles($paths);
 
@@ -114,5 +104,26 @@ final class CheckCommand extends Command
         sort($usedNames);
 
         return $usedNames;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @return string[]
+     */
+    private static function resolveTypesToSkip(InputInterface $input): array
+    {
+        /** @var string[] $typesToSkip */
+        $typesToSkip = [];
+
+        if ($input->getOption('configuration') !== null) {
+            $config = Yaml::parseFile($input->getOption('configuration'));
+            $typesToSkip = $config['typesToSkip'] ?? [];
+        }
+
+        if (count($input->getOption('skip-type')) > 0) {
+            $typesToSkip = (array)$input->getOption('skip-type');
+        }
+
+        return $typesToSkip;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "illuminate/container": "^10.15",
         "nikic/php-parser": "^4.16",
         "symfony/console": "^6.3",
+        "symfony/yaml": "^6.3",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {


### PR DESCRIPTION
The expected format is YAML and the only supported top level key is `typesToSkip`.

Resolves #8