### PR TITLE
Added failling PHPDoc types test

### DIFF
--- a/tests/UseImportsResolver/Fixture/PHPDocTyped.php
+++ b/tests/UseImportsResolver/Fixture/PHPDocTyped.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\UseImportsResolver\Fixture;
+
+final class PHPDocTyped
+{
+    /**
+     * @param \TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\FirstUsedClass $firstUsed
+     */
+    public function run($firstUsed)
+    {
+        /** @var \TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\SecondUsedClass $x */
+        $x = someFunction();
+        return $x;
+    }
+}

--- a/tests/UseImportsResolver/Fixture/PHPDocTyped.php
+++ b/tests/UseImportsResolver/Fixture/PHPDocTyped.php
@@ -8,6 +8,8 @@ final class PHPDocTyped
 {
     /**
      * @param \TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\FirstUsedClass $firstUsed
+     *
+     * @return \TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\ThirdUsedClass
      */
     public function run($firstUsed)
     {

--- a/tests/UseImportsResolver/UseImportsResolverTest.php
+++ b/tests/UseImportsResolver/UseImportsResolverTest.php
@@ -35,5 +35,6 @@ final class UseImportsResolverTest extends AbstractTestCase
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/FileUsingOtherClasses.php', [FirstUsedClass::class, SecondUsedClass::class]];
+        yield [__DIR__ . '/Fixture/PHPDocTyped.php', [FirstUsedClass::class, SecondUsedClass::class]];
     }
 }

--- a/tests/UseImportsResolver/UseImportsResolverTest.php
+++ b/tests/UseImportsResolver/UseImportsResolverTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
 use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\FirstUsedClass;
 use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\SecondUsedClass;
+use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\ThirdUsedClass;
 use TomasVotruba\ClassLeak\UseImportsResolver;
 
 final class UseImportsResolverTest extends AbstractTestCase
@@ -35,6 +36,6 @@ final class UseImportsResolverTest extends AbstractTestCase
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/FileUsingOtherClasses.php', [FirstUsedClass::class, SecondUsedClass::class]];
-        yield [__DIR__ . '/Fixture/PHPDocTyped.php', [FirstUsedClass::class, SecondUsedClass::class]];
+        yield [__DIR__ . '/Fixture/PHPDocTyped.php', [FirstUsedClass::class, SecondUsedClass::class, ThirdUsedClass::class]];
     }
 }


### PR DESCRIPTION
the same is true for generics aka. `@template` phpdoc tags.

just submitting the failing test for now. I have no idea how we should implement it right now