### PR TITLE
Fix critical bug in hasApiTag

### DIFF
--- a/app/NodeVisitor/ClassNameNodeVisitor.php
+++ b/app/NodeVisitor/ClassNameNodeVisitor.php
@@ -67,8 +67,6 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return false;
         }
 
-        preg_match(self::API_TAG_REGEX, $doc->getText(), $matches);
-
-        return $matches !== null;
+        return preg_match(self::API_TAG_REGEX, $doc->getText(), $matches) === 1;
     }
 }


### PR DESCRIPTION
`preg_match` signals a match in its return value.
Without a match the `matches` array is empty, not null.

@TomasVotruba 
