### PR TITLE
DX: Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require tomasvotruba/class-leak --dev
 Pass directories you want to check:
 
 ```bash
-vendor/bin/class-leak check bin src
+vendor/bin/class-leak check bin/ src/
 ```
 
 Make sure to exclude `/tests` directories, to keep reporting classes that are used in tests, but never used in the code-base.
@@ -25,13 +25,13 @@ Make sure to exclude `/tests` directories, to keep reporting classes that are us
 Many types are excluded by default, as they're collected by framework magic, e.g. console command classes. To exclude another class, e.g. your interface collector, use `--skip-type`:
 
 ```bash
-vendor/bin/class-leak check bin src --skip-type="App\\Contract\\SomeInterface"
+vendor/bin/class-leak check bin/ src/ --skip-type="App\\Contract\\SomeInterface"
 ```
 
 What if your classes do no implement any type? Use `--skip-suffix` instead:
 
 ```bash
-vendor/bin/class-leak check bin src --skip-suffix "Controller"
+vendor/bin/class-leak check bin/ src/ --skip-suffix "Controller"
 ```
 
 <br>


### PR DESCRIPTION
the trailling slashes in the command args help a developer new to the tool, to identify which args passed to the tool are just "magic strings" like `detect` and which are regular filesystem paths, like `src/ tests/` in this example