### PR TITLE
Prevent fatal error when class cannot be autoloaded

### DIFF
--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -90,7 +90,7 @@ final class PossiblyUnusedClassesFilter
     private function isClassSkipped(FileWithClass $fileWithClass, string $typeToSkip): bool
     {
         if (! str_contains($typeToSkip, '*')) {
-            return is_a($fileWithClass->getClassName(), $typeToSkip, true);
+            return class_exists($fileWithClass->getClassName(), true) && is_a($fileWithClass->getClassName(), $typeToSkip, true);
         }
 
         // try fnmatch


### PR DESCRIPTION
I was not able to write a automated test for it 🤷‍♂️

closes https://github.com/TomasVotruba/class-leak/issues/12