### PR TITLE
Support skipping class and method attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ What if your classes do no implement any type? Use `--skip-suffix` instead:
 vendor/bin/class-leak check bin src --skip-suffix "Controller"
 ```
 
+If you want to skip classes that use a specific attribute or have methods that use a specific attribute, use `--skip-attribute`:
+
+```bash
+vendor/bin/class-leak check bin src --skip-attribute "Symfony\\Component\\HttpKernel\\Attribute\\AsController"
+```
+
 <br>
 
 Happy coding!

--- a/scoper.php
+++ b/scoper.php
@@ -23,11 +23,18 @@ return [
                 return $content;
             }
 
-            return preg_replace_callback('#DEFAULT_TYPES_TO_SKIP = (?<content>.*?)\;#ms', function (array $match) use (
+            $content = preg_replace_callback('#DEFAULT_TYPES_TO_SKIP = (?<content>.*?)\;#ms', function (array $match) use (
                 $prefix
             ) {
                 $unprefixedValue = preg_replace('#\'' . $prefix . '\\\\#', '\'', $match['content']);
                 return 'DEFAULT_TYPES_TO_SKIP = ' . $unprefixedValue . ';';
+            }, $content);
+
+            return preg_replace_callback('#DEFAULT_ATTRIBUTES_TO_SKIP = (?<content>.*?)\;#ms', function (array $match) use (
+                $prefix
+            ) {
+                $unprefixedValue = preg_replace('#\'' . $prefix . '\\\\#', '\'', $match['content']);
+                return 'DEFAULT_ATTRIBUTES_TO_SKIP = ' . $unprefixedValue . ';';
             }, $content);
         },
     ],

--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -43,6 +43,11 @@ final readonly class ClassNameResolver
             return null;
         }
 
-        return new ClassNames($className, $classNameNodeVisitor->hasParentClassOrInterface());
+        return new ClassNames(
+            $className,
+            $classNameNodeVisitor->hasParentClassOrInterface(),
+            $classNameNodeVisitor->getAttributes(),
+            $classNameNodeVisitor->getAttributesByMethod(),
+        );
     }
 }

--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -47,7 +47,6 @@ final readonly class ClassNameResolver
             $className,
             $classNameNodeVisitor->hasParentClassOrInterface(),
             $classNameNodeVisitor->getAttributes(),
-            $classNameNodeVisitor->getAttributesByMethod(),
         );
     }
 }

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -57,6 +57,13 @@ final class CheckCommand extends Command
         );
 
         $this->addOption(
+            'skip-attribute',
+            null,
+            InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+            'Class attribute that should be skipped'
+        );
+
+        $this->addOption(
             'file-extension',
             null,
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
@@ -77,6 +84,9 @@ final class CheckCommand extends Command
 
         /** @var string[] $suffixesToSkip */
         $suffixesToSkip = (array) $input->getOption('skip-suffix');
+
+        /** @var string[] $attributesToSkip */
+        $attributesToSkip = (array) $input->getOption('skip-attribute');
 
         $isJson = (bool) $input->getOption('json');
 
@@ -104,7 +114,8 @@ final class CheckCommand extends Command
             $existingFilesWithClasses,
             $usedNames,
             $typesToSkip,
-            $suffixesToSkip
+            $suffixesToSkip,
+            $attributesToSkip
         );
 
         $unusedClassesResult = $this->unusedClassesResultFactory->create($possiblyUnusedFilesWithClasses);

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -43,10 +43,20 @@ final class PossiblyUnusedClassesFilter
     ];
 
     /**
+     * @var string[]
+     */
+    private const DEFAULT_ATTRIBUTES_TO_SKIP = [
+        'Symfony\Component\Console\Attribute\AsCommand',
+        'Symfony\Component\HttpKernel\Attribute\AsController',
+        'Symfony\Component\EventDispatcher\Attribute\AsEventListener'
+    ];
+
+    /**
      * @param FileWithClass[] $filesWithClasses
      * @param string[] $usedClassNames
      * @param string[] $typesToSkip
      * @param string[] $suffixesToSkip
+     * @param string[] $attributesToSkip
      *
      * @return FileWithClass[]
      */
@@ -54,7 +64,8 @@ final class PossiblyUnusedClassesFilter
         array $filesWithClasses,
         array $usedClassNames,
         array $typesToSkip,
-        array $suffixesToSkip
+        array $suffixesToSkip,
+        array $attributesToSkip
     ): array {
         Assert::allString($usedClassNames);
         Assert::allString($typesToSkip);
@@ -63,6 +74,7 @@ final class PossiblyUnusedClassesFilter
         $possiblyUnusedFilesWithClasses = [];
 
         $typesToSkip = [...$typesToSkip, ...self::DEFAULT_TYPES_TO_SKIP];
+        $attributesToSkip = [...$attributesToSkip, ...self::DEFAULT_ATTRIBUTES_TO_SKIP];
 
         foreach ($filesWithClasses as $fileWithClass) {
             if (in_array($fileWithClass->getClassName(), $usedClassNames, true)) {
@@ -80,6 +92,17 @@ final class PossiblyUnusedClassesFilter
             foreach ($suffixesToSkip as $suffixToSkip) {
                 if (str_ends_with($fileWithClass->getClassName(), $suffixToSkip)) {
                     continue 2;
+                }
+            }
+
+            foreach ($attributesToSkip as $attributeToSkip) {
+                if (in_array($attributeToSkip, $fileWithClass->getAttributes(), true)) {
+                    continue 2;
+                }
+                foreach ($fileWithClass->getAttributesByMethod() as $attributes) {
+                    if (in_array($attributeToSkip, $attributes, true)) {
+                        continue 3;
+                    }
                 }
             }
 

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -101,15 +101,6 @@ final class PossiblyUnusedClassesFilter
                 }
             }
 
-            // is excluded attributes by method?
-            foreach ($fileWithClass->getAttributesByMethod() as $attributes) {
-                foreach ($attributes as $attribute) {
-                    if ($this->shouldSkip($attribute, $attributesToSkip)) {
-                        continue 3;
-                    }
-                }
-            }
-
             $possiblyUnusedFilesWithClasses[] = $fileWithClass;
         }
 

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -46,6 +46,7 @@ final class PossiblyUnusedClassesFilter
      * @var string[]
      */
     private const DEFAULT_ATTRIBUTES_TO_SKIP = [
+        // symfony
         'Symfony\Component\Console\Attribute\AsCommand',
         'Symfony\Component\HttpKernel\Attribute\AsController',
         'Symfony\Component\EventDispatcher\Attribute\AsEventListener'

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -46,7 +46,7 @@ final class PossiblyUnusedClassesFilter
      * @var string[]
      */
     private const DEFAULT_ATTRIBUTES_TO_SKIP = [
-        // symfony
+        // Symfony
         'Symfony\Component\Console\Attribute\AsCommand',
         'Symfony\Component\HttpKernel\Attribute\AsController',
         'Symfony\Component\EventDispatcher\Attribute\AsEventListener'

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -84,7 +84,7 @@ final class PossiblyUnusedClassesFilter
 
             // is excluded interfaces?
             foreach ($typesToSkip as $typeToSkip) {
-                if ($this->isClassSkipped($fileWithClass, $typeToSkip)) {
+                if ($this->shouldSkip($fileWithClass->getClassName(), $typeToSkip)) {
                     continue 2;
                 }
             }
@@ -96,13 +96,22 @@ final class PossiblyUnusedClassesFilter
                 }
             }
 
-            foreach ($attributesToSkip as $attributeToSkip) {
-                if (in_array($attributeToSkip, $fileWithClass->getAttributes(), true)) {
-                    continue 2;
-                }
-                foreach ($fileWithClass->getAttributesByMethod() as $attributes) {
-                    if (in_array($attributeToSkip, $attributes, true)) {
+            // is excluded attributes?
+            foreach ($fileWithClass->getAttributes() as $attribute) {
+                foreach ($attributesToSkip as $attributeToSkip) {
+                    if ($this->shouldSkip($attribute, $attributeToSkip)) {
                         continue 3;
+                    }
+                }
+            }
+
+            // is excluded attributes by method?
+            foreach ($fileWithClass->getAttributesByMethod() as $attributes) {
+                foreach ($attributes as $attribute) {
+                    foreach ($attributesToSkip as $attributeToSkip) {
+                        if ($this->shouldSkip($attribute, $attributeToSkip)) {
+                            continue 4;
+                        }
                     }
                 }
             }
@@ -113,13 +122,13 @@ final class PossiblyUnusedClassesFilter
         return $possiblyUnusedFilesWithClasses;
     }
 
-    private function isClassSkipped(FileWithClass $fileWithClass, string $typeToSkip): bool
+    private function shouldSkip($type, string $skip): bool
     {
-        if (! str_contains($typeToSkip, '*')) {
-            return is_a($fileWithClass->getClassName(), $typeToSkip, true);
+        if (! str_contains($type, '*')) {
+            return is_a($type, $skip, true);
         }
 
         // try fnmatch
-        return fnmatch($typeToSkip, $fileWithClass->getClassName(), FNM_NOESCAPE);
+        return fnmatch($skip, $type, FNM_NOESCAPE);
     }
 }

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -83,10 +83,8 @@ final class PossiblyUnusedClassesFilter
             }
 
             // is excluded interfaces?
-            foreach ($typesToSkip as $typeToSkip) {
-                if ($this->shouldSkip($fileWithClass->getClassName(), $typeToSkip)) {
-                    continue 2;
-                }
+            if ($this->shouldSkip($fileWithClass->getClassName(), $typesToSkip)) {
+                continue;
             }
 
             // is excluded suffix?
@@ -98,20 +96,16 @@ final class PossiblyUnusedClassesFilter
 
             // is excluded attributes?
             foreach ($fileWithClass->getAttributes() as $attribute) {
-                foreach ($attributesToSkip as $attributeToSkip) {
-                    if ($this->shouldSkip($attribute, $attributeToSkip)) {
-                        continue 3;
-                    }
+                if ($this->shouldSkip($attribute, $attributesToSkip)) {
+                    continue 2;
                 }
             }
 
             // is excluded attributes by method?
             foreach ($fileWithClass->getAttributesByMethod() as $attributes) {
                 foreach ($attributes as $attribute) {
-                    foreach ($attributesToSkip as $attributeToSkip) {
-                        if ($this->shouldSkip($attribute, $attributeToSkip)) {
-                            continue 4;
-                        }
+                    if ($this->shouldSkip($attribute, $attributesToSkip)) {
+                        continue 3;
                     }
                 }
             }
@@ -122,13 +116,21 @@ final class PossiblyUnusedClassesFilter
         return $possiblyUnusedFilesWithClasses;
     }
 
-    private function shouldSkip(string $type, string $skip): bool
+    /**
+     * @param string[] $skips
+     */
+    private function shouldSkip(string $type, array $skips): bool
     {
-        if (! str_contains($type, '*')) {
-            return is_a($type, $skip, true);
+        foreach ($skips as $skip) {
+            if (! str_contains($type, '*') && is_a($type, $skip, true)) {
+                return true;
+            }
+
+            if (fnmatch($skip, $type, FNM_NOESCAPE)) {
+                return true;
+            }
         }
 
-        // try fnmatch
-        return fnmatch($skip, $type, FNM_NOESCAPE);
+        return false;
     }
 }

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -38,6 +38,8 @@ final class PossiblyUnusedClassesFilter
         'Illuminate\Foundation\Http\Kernel',
         'Illuminate\Contracts\Console\Kernel',
         'Illuminate\Routing\Controller',
+        // doctrine
+        'Doctrine\Migrations\AbstractMigration',
     ];
 
     /**

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -38,7 +38,7 @@ final class PossiblyUnusedClassesFilter
         'Illuminate\Foundation\Http\Kernel',
         'Illuminate\Contracts\Console\Kernel',
         'Illuminate\Routing\Controller',
-        // doctrine
+        // Doctrine
         'Doctrine\Migrations\AbstractMigration',
     ];
 

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -122,7 +122,7 @@ final class PossiblyUnusedClassesFilter
         return $possiblyUnusedFilesWithClasses;
     }
 
-    private function shouldSkip($type, string $skip): bool
+    private function shouldSkip(string $type, string $skip): bool
     {
         if (! str_contains($type, '*')) {
             return is_a($type, $skip, true);

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -34,7 +34,6 @@ final readonly class ClassNamesFinder
                 $classNames->getClassName(),
                 $classNames->hasParentClassOrInterface(),
                 $classNames->getAttributes(),
-                $classNames->getAttributesByMethod(),
             );
         }
 

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -32,7 +32,9 @@ final readonly class ClassNamesFinder
             $filesWithClasses[] = new FileWithClass(
                 $filePath,
                 $classNames->getClassName(),
-                $classNames->hasParentClassOrInterface()
+                $classNames->hasParentClassOrInterface(),
+                $classNames->getAttributes(),
+                $classNames->getAttributesByMethod(),
             );
         }
 

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -88,10 +88,10 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             }
         }
 
-        foreach ($node->getMethods() as $method) {
-            foreach ($method->attrGroups as $attrGroup) {
+        foreach ($node->getMethods() as $classMethod) {
+            foreach ($classMethod->attrGroups as $attrGroup) {
                 foreach ($attrGroup->attrs as $attr) {
-                    $this->attributesByMethod[$method->name->toString()][] = $attr->name->toString();
+                    $this->attributesByMethod[$classMethod->name->toString()][] = $attr->name->toString();
                 }
             }
         }

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -27,6 +27,13 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private bool $hasParentClassOrInterface = false;
 
     /**
+     * @var string[]
+     */
+    private array $attributes = [];
+
+    private array $attributesByMethod = [];
+
+    /**
      * @param Node\Stmt[] $nodes
      * @return Node\Stmt[]
      */
@@ -34,6 +41,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     {
         $this->className = null;
         $this->hasParentClassOrInterface = false;
+        $this->attributes = [];
 
         return $nodes;
     }
@@ -71,6 +79,20 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             $this->hasParentClassOrInterface = true;
         }
 
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $this->attributes[] = $attr->name->toString();
+            }
+        }
+
+        foreach ($node->getMethods() as $method) {
+            foreach ($method->attrGroups as $attrGroup) {
+                foreach ($attrGroup->attrs as $attr) {
+                    $this->attributesByMethod[$method->name->toString()][] = $attr->name->toString();
+                }
+            }
+        }
+
         return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
     }
 
@@ -82,6 +104,22 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     public function hasParentClassOrInterface(): bool
     {
         return $this->hasParentClassOrInterface;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAttributes() : array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getAttributesByMethod() : array
+    {
+        return $this->attributesByMethod;
     }
 
     private function hasApiTag(ClassLike $classLike): bool

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -31,6 +31,9 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
      */
     private array $attributes = [];
 
+    /**
+     * @var array<string, string[]>
+     */
     private array $attributesByMethod = [];
 
     /**

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -32,11 +32,6 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private array $attributes = [];
 
     /**
-     * @var array<string, string[]>
-     */
-    private array $attributesByMethod = [];
-
-    /**
      * @param Node\Stmt[] $nodes
      * @return Node\Stmt[]
      */
@@ -91,7 +86,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         foreach ($node->getMethods() as $classMethod) {
             foreach ($classMethod->attrGroups as $attrGroup) {
                 foreach ($attrGroup->attrs as $attr) {
-                    $this->attributesByMethod[$classMethod->name->toString()][] = $attr->name->toString();
+                    $this->attributes[] = $attr->name->toString();
                 }
             }
         }
@@ -114,15 +109,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
      */
     public function getAttributes() : array
     {
-        return $this->attributes;
-    }
-
-    /**
-     * @return array<string, string[]>
-     */
-    public function getAttributesByMethod() : array
-    {
-        return $this->attributesByMethod;
+        return array_unique($this->attributes);
     }
 
     private function hasApiTag(ClassLike $classLike): bool

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -8,13 +8,11 @@ final readonly class ClassNames
 {
     /**
      * @param string[] $attributes
-     * @param array<string, string[]> $attributesByMethod
      */
     public function __construct(
         private string $className,
         private bool $hasParentClassOrInterface,
         private array $attributes,
-        private array $attributesByMethod,
     ) {
     }
 
@@ -34,13 +32,5 @@ final readonly class ClassNames
     public function getAttributes(): array
     {
         return $this->attributes;
-    }
-
-    /**
-     * @return array<string, string[]>
-     */
-    public function getAttributesByMethod() : array
-    {
-        return $this->attributesByMethod;
     }
 }

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -8,7 +8,7 @@ final readonly class ClassNames
 {
     /**
      * @param string[] $attributes
-     * @param array<string, string[]> $methods
+     * @param array<string, string[]> $attributesByMethod
      */
     public function __construct(
         private string $className,

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -6,9 +6,15 @@ namespace TomasVotruba\ClassLeak\ValueObject;
 
 final readonly class ClassNames
 {
+    /**
+     * @param string[] $attributes
+     * @param array<string, string[]> $methods
+     */
     public function __construct(
         private string $className,
-        private bool $hasParentClassOrInterface
+        private bool $hasParentClassOrInterface,
+        private array $attributes,
+        private array $attributesByMethod,
     ) {
     }
 
@@ -20,5 +26,21 @@ final readonly class ClassNames
     public function hasParentClassOrInterface(): bool
     {
         return $this->hasParentClassOrInterface;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getAttributesByMethod() : array
+    {
+        return $this->attributesByMethod;
     }
 }

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -44,7 +44,7 @@ final readonly class FileWithClass implements JsonSerializable
     }
 
     /**
-     * @return array{file_path: string, class: string, attributes: string[]>}
+     * @return array{file_path: string, class: string, attributes: string[]}
      */
     public function jsonSerialize(): array
     {

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -9,10 +9,16 @@ use TomasVotruba\ClassLeak\FileSystem\StaticRelativeFilePathHelper;
 
 final readonly class FileWithClass implements JsonSerializable
 {
+    /**
+     * @param string[] $attributes
+     * @param array<string, string[]> $attributesByMethod
+     */
     public function __construct(
         private string $filePath,
         private string $className,
-        private bool $hasParentClassOrInterface
+        private bool $hasParentClassOrInterface,
+        private array $attributes,
+        private array $attributesByMethod,
     ) {
     }
 
@@ -32,13 +38,31 @@ final readonly class FileWithClass implements JsonSerializable
     }
 
     /**
-     * @return array{file_path: string, class: string}
+     * @return string[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getAttributesByMethod(): array
+    {
+        return $this->attributesByMethod;
+    }
+
+    /**
+     * @return array{file_path: string, class: string, attributes: string[], attributesByMethod: array<string, string[]>}
      */
     public function jsonSerialize(): array
     {
         return [
             'file_path' => $this->filePath,
             'class' => $this->className,
+            'attributes' => $this->attributes,
+            'attributesByMethod' => $this->attributesByMethod,
         ];
     }
 }

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -11,14 +11,12 @@ final readonly class FileWithClass implements JsonSerializable
 {
     /**
      * @param string[] $attributes
-     * @param array<string, string[]> $attributesByMethod
      */
     public function __construct(
         private string $filePath,
         private string $className,
         private bool $hasParentClassOrInterface,
         private array $attributes,
-        private array $attributesByMethod,
     ) {
     }
 
@@ -46,15 +44,7 @@ final readonly class FileWithClass implements JsonSerializable
     }
 
     /**
-     * @return array<string, string[]>
-     */
-    public function getAttributesByMethod(): array
-    {
-        return $this->attributesByMethod;
-    }
-
-    /**
-     * @return array{file_path: string, class: string, attributes: string[], attributesByMethod: array<string, string[]>}
+     * @return array{file_path: string, class: string, attributes: string[]>}
      */
     public function jsonSerialize(): array
     {
@@ -62,7 +52,6 @@ final readonly class FileWithClass implements JsonSerializable
             'file_path' => $this->filePath,
             'class' => $this->className,
             'attributes' => $this->attributes,
-            'attributesByMethod' => $this->attributesByMethod,
         ];
     }
 }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -8,7 +8,9 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\ClassNameResolver;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeClass;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeMethodAttribute;
 use TomasVotruba\ClassLeak\ValueObject\ClassNames;
 
 final class ClassNameResolverTest extends AbstractTestCase
@@ -33,10 +35,20 @@ final class ClassNameResolverTest extends AbstractTestCase
             $expectedClassNames->hasParentClassOrInterface(),
             $resolvedClassNames->hasParentClassOrInterface()
         );
+        $this->assertSame($expectedClassNames->getAttributes(), $resolvedClassNames->getAttributes());
+        $this->assertSame($expectedClassNames->getAttributesByMethod(), $resolvedClassNames->getAttributesByMethod());
     }
 
     public static function provideData(): Iterator
     {
-        yield [__DIR__ . '/Fixture/SomeClass.php', new ClassNames(SomeClass::class, false)];
+        yield [
+            __DIR__ . '/Fixture/SomeClass.php',
+            new ClassNames(
+                SomeClass::class,
+                false,
+                [SomeAttribute::class],
+                ['myMethod' => [SomeMethodAttribute::class]],
+            ),
+        ];
     }
 }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -36,7 +36,6 @@ final class ClassNameResolverTest extends AbstractTestCase
             $resolvedClassNames->hasParentClassOrInterface()
         );
         $this->assertSame($expectedClassNames->getAttributes(), $resolvedClassNames->getAttributes());
-        $this->assertSame($expectedClassNames->getAttributesByMethod(), $resolvedClassNames->getAttributesByMethod());
     }
 
     public static function provideData(): Iterator
@@ -46,8 +45,7 @@ final class ClassNameResolverTest extends AbstractTestCase
             new ClassNames(
                 SomeClass::class,
                 false,
-                [SomeAttribute::class],
-                ['myMethod' => [SomeMethodAttribute::class]],
+                [SomeAttribute::class, SomeMethodAttribute::class],
             ),
         ];
     }

--- a/tests/ClassNameResolver/Fixture/SomeAttribute.php
+++ b/tests/ClassNameResolver/Fixture/SomeAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+use Attribute;
+
+#[Attribute]
+class SomeAttribute
+{
+
+}

--- a/tests/ClassNameResolver/Fixture/SomeClass.php
+++ b/tests/ClassNameResolver/Fixture/SomeClass.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
+#[SomeAttribute]
 final class SomeClass
 {
+    #[SomeMethodAttribute]
+    public function myMethod(): void
+    {
+    }
 }

--- a/tests/ClassNameResolver/Fixture/SomeMethodAttribute.php
+++ b/tests/ClassNameResolver/Fixture/SomeMethodAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class SomeMethodAttribute
+{
+
+}


### PR DESCRIPTION
This makes it possible to skip classes that are tagged with a specific attribute.

It also makes it possible to skip methods that have a certain attribute. This is useful,
because sometimes attributes are only defined on the methods.

Fixes #10
