### PR TITLE
Fix bug that causes a class to be skipped when it has any doc comment (related to `@api` doc filtering)

### DIFF
--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -46,6 +46,7 @@ final readonly class ClassNameResolver
         return new ClassNames(
             $className,
             $classNameNodeVisitor->hasParentClassOrInterface(),
+            $classNameNodeVisitor->hasApiTag(),
             $classNameNodeVisitor->getAttributes(),
         );
     }

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -78,6 +78,10 @@ final class PossiblyUnusedClassesFilter
         $attributesToSkip = [...$attributesToSkip, ...self::DEFAULT_ATTRIBUTES_TO_SKIP];
 
         foreach ($filesWithClasses as $fileWithClass) {
+            if ($fileWithClass->hasApiTag()) {
+                continue;
+            }
+
             if (in_array($fileWithClass->getClassName(), $usedClassNames, true)) {
                 continue;
             }

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -33,6 +33,7 @@ final readonly class ClassNamesFinder
                 $filePath,
                 $classNames->getClassName(),
                 $classNames->hasParentClassOrInterface(),
+                $classNames->hasApiTag(),
                 $classNames->getAttributes(),
             );
         }

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -126,8 +126,6 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return false;
         }
 
-        preg_match(self::API_TAG_REGEX, $doc->getText(), $matches);
-
-        return $matches !== null;
+        return preg_match(self::API_TAG_REGEX, $doc->getText()) === 1;
     }
 }

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -25,6 +25,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private string|null $className = null;
 
     private bool $hasParentClassOrInterface = false;
+
     private bool $hasApiTag = false;
 
     /**

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -25,6 +25,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private string|null $className = null;
 
     private bool $hasParentClassOrInterface = false;
+    private bool $hasApiTag = false;
 
     /**
      * @var string[]
@@ -39,6 +40,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     {
         $this->className = null;
         $this->hasParentClassOrInterface = false;
+        $this->hasApiTag = false;
         $this->attributes = [];
 
         return $nodes;
@@ -54,8 +56,8 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        if ($this->hasApiTag($node)) {
-            return null;
+        if ($this->doesClassHaveApiTag($node)) {
+            $this->hasApiTag = true;
         }
 
         if (! $node->namespacedName instanceof Name) {
@@ -104,6 +106,11 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         return $this->hasParentClassOrInterface;
     }
 
+    public function hasApiTag() : bool
+    {
+        return $this->hasApiTag;
+    }
+
     /**
      * @return string[]
      */
@@ -112,7 +119,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         return array_unique($this->attributes);
     }
 
-    private function hasApiTag(ClassLike $classLike): bool
+    private function doesClassHaveApiTag(ClassLike $classLike): bool
     {
         $doc = $classLike->getDocComment();
         if (! $doc instanceof Doc) {

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -12,6 +12,7 @@ final readonly class ClassNames
     public function __construct(
         private string $className,
         private bool $hasParentClassOrInterface,
+        private bool $hasApiTag,
         private array $attributes,
     ) {
     }
@@ -24,6 +25,11 @@ final readonly class ClassNames
     public function hasParentClassOrInterface(): bool
     {
         return $this->hasParentClassOrInterface;
+    }
+
+    public function hasApiTag() : bool
+    {
+        return $this->hasApiTag;
     }
 
     /**

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -16,6 +16,7 @@ final readonly class FileWithClass implements JsonSerializable
         private string $filePath,
         private string $className,
         private bool $hasParentClassOrInterface,
+        private bool $hasApiTag,
         private array $attributes,
     ) {
     }
@@ -35,6 +36,11 @@ final readonly class FileWithClass implements JsonSerializable
         return $this->hasParentClassOrInterface;
     }
 
+    public function hasApiTag(): bool
+    {
+        return $this->hasApiTag;
+    }
+
     /**
      * @return string[]
      */
@@ -44,13 +50,21 @@ final readonly class FileWithClass implements JsonSerializable
     }
 
     /**
-     * @return array{file_path: string, class: string, attributes: string[]}
+     * @return array{
+     *     file_path: string,
+     *     class: string,
+     *     has_parent_class_or_interface: bool,
+     *     has_api_tag: bool,
+     *     attributes: string[]
+     * }
      */
     public function jsonSerialize(): array
     {
         return [
             'file_path' => $this->filePath,
             'class' => $this->className,
+            'has_parent_class_or_interface' => $this->hasParentClassOrInterface,
+            'has_api_tag' => $this->hasApiTag,
             'attributes' => $this->attributes,
         ];
     }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -30,12 +30,7 @@ final class ClassNameResolverTest extends AbstractTestCase
         $resolvedClassNames = $this->classNameResolver->resolveFromFromFilePath($filePath);
         $this->assertInstanceOf(ClassNames::class, $resolvedClassNames);
 
-        $this->assertSame($expectedClassNames->getClassName(), $resolvedClassNames->getClassName());
-        $this->assertSame(
-            $expectedClassNames->hasParentClassOrInterface(),
-            $resolvedClassNames->hasParentClassOrInterface()
-        );
-        $this->assertSame($expectedClassNames->getAttributes(), $resolvedClassNames->getAttributes());
+        $this->assertEquals($expectedClassNames, $resolvedClassNames);
     }
 
     public static function provideData(): Iterator
@@ -45,6 +40,7 @@ final class ClassNameResolverTest extends AbstractTestCase
             new ClassNames(
                 SomeClass::class,
                 false,
+                true,
                 [SomeAttribute::class, SomeMethodAttribute::class],
             ),
         ];

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\ClassNameResolver;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\ClassWithOtherComment;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeClass;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeMethodAttribute;
@@ -42,6 +43,15 @@ final class ClassNameResolverTest extends AbstractTestCase
                 false,
                 true,
                 [SomeAttribute::class, SomeMethodAttribute::class],
+            ),
+        ];
+        yield [
+            __DIR__ . '/Fixture/ClassWithOtherComment.php',
+            new ClassNames(
+                ClassWithOtherComment::class,
+                false,
+                false,
+                [],
             ),
         ];
     }

--- a/tests/ClassNameResolver/Fixture/ClassWithOtherComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithOtherComment.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+/**
+ * Some comment
+ */
+final readonly class ClassWithOtherComment
+{
+
+}

--- a/tests/ClassNameResolver/Fixture/SomeClass.php
+++ b/tests/ClassNameResolver/Fixture/SomeClass.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
+/**
+ * @api
+ */
 #[SomeAttribute]
 final class SomeClass
 {

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\Filtering;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use TomasVotruba\ClassLeak\Filtering\PossiblyUnusedClassesFilter;
+use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
+
+final class PossiblyUnusedClassesFilterTest extends TestCase
+{
+    private PossiblyUnusedClassesFilter $filter;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->filter = new PossiblyUnusedClassesFilter();
+    }
+
+    /**
+     * @param FileWithClass[] $filesWithClasses
+     * @param string[] $usedClassNames
+     * @param string[] $typesToSkip
+     * @param string[] $suffixesToSkip
+     * @param string[] $attributesToSkip
+     */
+    #[DataProvider('provideData')]
+    public function test(
+        array $filesWithClasses,
+        array $usedClassNames,
+        array $typesToSkip,
+        array $suffixesToSkip,
+        array $attributesToSkip,
+        array $expectedFilteredFilesWithClasses,
+    ) : void {
+        self::assertEquals(
+            $expectedFilteredFilesWithClasses,
+            $this->filter->filter(
+                $filesWithClasses,
+                $usedClassNames,
+                $typesToSkip,
+                $suffixesToSkip,
+                $attributesToSkip,
+            ),
+        );
+    }
+
+    public static function provideData() : iterable
+    {
+        yield 'it should not filter' => [
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    false,
+                    [],
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    false,
+                    [],
+                ),
+            ],
+        ];
+
+        yield 'it should filter class with api tag' => [
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    true,
+                    [],
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
+        ];
+    }
+}

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -12,13 +12,13 @@ use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
 
 final class PossiblyUnusedClassesFilterTest extends TestCase
 {
-    private PossiblyUnusedClassesFilter $filter;
+    private PossiblyUnusedClassesFilter $possiblyUnusedClassesFilter;
 
     protected function setUp() : void
     {
         parent::setUp();
 
-        $this->filter = new PossiblyUnusedClassesFilter();
+        $this->possiblyUnusedClassesFilter = new PossiblyUnusedClassesFilter();
     }
 
     /**
@@ -27,6 +27,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
      * @param string[] $typesToSkip
      * @param string[] $suffixesToSkip
      * @param string[] $attributesToSkip
+     * @param FileWithClass[] $expectedFilteredFilesWithClasses
      */
     #[DataProvider('provideData')]
     public function test(
@@ -39,7 +40,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
     ) : void {
         self::assertEquals(
             $expectedFilteredFilesWithClasses,
-            $this->filter->filter(
+            $this->possiblyUnusedClassesFilter->filter(
                 $filesWithClasses,
                 $usedClassNames,
                 $typesToSkip,
@@ -49,6 +50,9 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
         );
     }
 
+    /**
+     * @return iterable<string, array{FileWithClass[], string[], string[], string[], string[], FileWithClass[]}>
+     */
     public static function provideData() : iterable
     {
         yield 'it should not filter' => [

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\Filtering;
 
-use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TomasVotruba\ClassLeak\Filtering\PossiblyUnusedClassesFilter;


### PR DESCRIPTION
> [!NOTE]
> Found a bug. Any class that has a doc comment is always skipped. This PR fixes the issue.

### Move `@api` exclusion to filter stage

When we're searching for classes in a given file, we want to get the class, no matter if `@api` is used or not.
Not returning a class when it's there feel wrong.

We detect the `@api` comment, and place that on the ClassNames object. We pass that along to FileWithClass.

Then the PossiblyUnusedClassesFilter can filter classes with `@api` tag.

Also added a few test cases.

### Add failing test case when class does have a comment

### Fix `@api` preg_match

We should check if `preg_match` returns `1`.

Otherwise we always match.
