### PR TITLE
Search for used names in PHPDoc comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "illuminate/container": "^10.43",
         "nette/utils": "^3.2",
         "nikic/php-parser": "^4.18",
+        "phpstan/phpdoc-parser": "^1.27",
         "symfony/console": "^6.3",
         "symfony/finder": "^6.3",
         "webmozart/assert": "^1.11"

--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -48,6 +48,7 @@ final readonly class ClassNameResolver
             $classNameNodeVisitor->hasParentClassOrInterface(),
             $classNameNodeVisitor->hasApiTag(),
             $classNameNodeVisitor->getUsedAttributes(),
+            $classNameNodeVisitor->getImports()
         );
     }
 }

--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -46,6 +46,7 @@ final readonly class ClassNameResolver
         return new ClassNames(
             $className,
             $classNameNodeVisitor->hasParentClassOrInterface(),
+            $classNameNodeVisitor->hasApiTag(),
             $classNameNodeVisitor->getAttributes(),
         );
     }

--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -47,7 +47,7 @@ final readonly class ClassNameResolver
             $className,
             $classNameNodeVisitor->hasParentClassOrInterface(),
             $classNameNodeVisitor->hasApiTag(),
-            $classNameNodeVisitor->getAttributes(),
+            $classNameNodeVisitor->getUsedAttributes(),
         );
     }
 }

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -99,7 +99,7 @@ final class PossiblyUnusedClassesFilter
             }
 
             // is excluded attributes?
-            foreach ($fileWithClass->getAttributes() as $attribute) {
+            foreach ($fileWithClass->getUsedAttributes() as $attribute) {
                 if ($this->shouldSkip($attribute, $attributesToSkip)) {
                     continue 2;
                 }

--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -78,6 +78,10 @@ final class PossiblyUnusedClassesFilter
         $attributesToSkip = [...$attributesToSkip, ...self::DEFAULT_ATTRIBUTES_TO_SKIP];
 
         foreach ($filesWithClasses as $fileWithClass) {
+            if ($fileWithClass->hasApiTag()) {
+                continue;
+            }
+
             if (in_array($fileWithClass->getClassName(), $usedClassNames, true)) {
                 continue;
             }

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -34,7 +34,7 @@ final readonly class ClassNamesFinder
                 $classNames->getClassName(),
                 $classNames->hasParentClassOrInterface(),
                 $classNames->hasApiTag(),
-                $classNames->getAttributes(),
+                $classNames->getUsedAttributes(),
             );
         }
 

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -33,6 +33,7 @@ final readonly class ClassNamesFinder
                 $filePath,
                 $classNames->getClassName(),
                 $classNames->hasParentClassOrInterface(),
+                $classNames->hasApiTag(),
                 $classNames->getAttributes(),
             );
         }

--- a/src/Finder/ClassNamesFinder.php
+++ b/src/Finder/ClassNamesFinder.php
@@ -17,7 +17,7 @@ final readonly class ClassNamesFinder
 
     /**
      * @param string[] $filePaths
-     * @return FileWithClass[]
+     * @return array<string, FileWithClass>
      */
     public function resolveClassNamesToCheck(array $filePaths): array
     {
@@ -29,12 +29,13 @@ final readonly class ClassNamesFinder
                 continue;
             }
 
-            $filesWithClasses[] = new FileWithClass(
+            $filesWithClasses[$filePath] = new FileWithClass(
                 $filePath,
                 $classNames->getClassName(),
                 $classNames->hasParentClassOrInterface(),
                 $classNames->hasApiTag(),
                 $classNames->getUsedAttributes(),
+                $classNames->getImports()
             );
         }
 

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -126,8 +126,6 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return false;
         }
 
-        preg_match(self::API_TAG_REGEX, $doc->getText(), $matches);
-
-        return $matches !== null;
+        return preg_match(self::API_TAG_REGEX, $doc->getText()) === 1;
     }
 }

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -31,7 +31,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     /**
      * @var string[]
      */
-    private array $attributes = [];
+    private array $usedAttributes = [];
 
     /**
      * @param Node\Stmt[] $nodes
@@ -42,7 +42,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         $this->className = null;
         $this->hasParentClassOrInterface = false;
         $this->hasApiTag = false;
-        $this->attributes = [];
+        $this->usedAttributes = [];
 
         return $nodes;
     }
@@ -82,14 +82,14 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
 
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attr) {
-                $this->attributes[] = $attr->name->toString();
+                $this->usedAttributes[] = $attr->name->toString();
             }
         }
 
         foreach ($node->getMethods() as $classMethod) {
             foreach ($classMethod->attrGroups as $attrGroup) {
                 foreach ($attrGroup->attrs as $attr) {
-                    $this->attributes[] = $attr->name->toString();
+                    $this->usedAttributes[] = $attr->name->toString();
                 }
             }
         }
@@ -115,9 +115,9 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     /**
      * @return string[]
      */
-    public function getAttributes() : array
+    public function getUsedAttributes(): array
     {
-        return array_unique($this->attributes);
+        return array_unique($this->usedAttributes);
     }
 
     private function doesClassHaveApiTag(ClassLike $classLike): bool

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -25,6 +25,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private string|null $className = null;
 
     private bool $hasParentClassOrInterface = false;
+
     private bool $hasApiTag = false;
 
     /**

--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -25,6 +25,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     private string|null $className = null;
 
     private bool $hasParentClassOrInterface = false;
+    private bool $hasApiTag = false;
 
     /**
      * @var string[]
@@ -39,6 +40,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
     {
         $this->className = null;
         $this->hasParentClassOrInterface = false;
+        $this->hasApiTag = false;
         $this->attributes = [];
 
         return $nodes;
@@ -54,8 +56,8 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        if ($this->hasApiTag($node)) {
-            return null;
+        if ($this->doesClassHaveApiTag($node)) {
+            $this->hasApiTag = true;
         }
 
         if (! $node->namespacedName instanceof Name) {
@@ -104,6 +106,11 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         return $this->hasParentClassOrInterface;
     }
 
+    public function hasApiTag() : bool
+    {
+        return $this->hasApiTag;
+    }
+
     /**
      * @return string[]
      */
@@ -112,7 +119,7 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
         return array_unique($this->attributes);
     }
 
-    private function hasApiTag(ClassLike $classLike): bool
+    private function doesClassHaveApiTag(ClassLike $classLike): bool
     {
         $doc = $classLike->getDocComment();
         if (! $doc instanceof Doc) {

--- a/src/NodeVisitor/UsedClassNodeVisitor.php
+++ b/src/NodeVisitor/UsedClassNodeVisitor.php
@@ -9,17 +9,64 @@ use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use TomasVotruba\ClassLeak\PhpDocNodeVisitor\UsedTypeNodeVisitor;
 
 final class UsedClassNodeVisitor extends NodeVisitorAbstract
 {
     /**
      * @var string[]
      */
+    private const TYPES_TO_SKIP = [
+        'list',
+        'array',
+        'int',
+        'string',
+        'bool',
+        'float',
+        'object',
+        'mixed',
+        'null',
+        'void',
+        'callable',
+        'iterable',
+        'self',
+        'static',
+        'true',
+        'false',
+        'resource',
+    ];
+
+    /**
+     * @var string[]
+     */
     private array $usedNames = [];
+
+    /**
+     * @var string[]
+     */
+    private array $comments = [];
+
+    private readonly Lexer $lexer;
+
+    private readonly PhpDocParser $phpDocParser;
+
+    public function __construct()
+    {
+        $constExprParser = new ConstExprParser();
+
+        $this->lexer = new Lexer();
+        $this->phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
+    }
 
     /**
      * @param Stmt[] $nodes
@@ -28,6 +75,8 @@ final class UsedClassNodeVisitor extends NodeVisitorAbstract
     public function beforeTraverse(array $nodes): array
     {
         $this->usedNames = [];
+        $this->comments = [];
+
         return $nodes;
     }
 
@@ -35,6 +84,18 @@ final class UsedClassNodeVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof ConstFetch) {
             return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof ClassLike) {
+            if ($node->getDocComment() !== null) {
+                $this->comments[] = $node->getDocComment()->getText();
+            }
+
+            foreach ($node->getMethods() as $classMethod) {
+                if ($classMethod->getDocComment() !== null) {
+                    $this->comments[] = $classMethod->getDocComment()->getText();
+                }
+            }
         }
 
         if (! $node instanceof Name) {
@@ -57,10 +118,27 @@ final class UsedClassNodeVisitor extends NodeVisitorAbstract
      */
     public function getUsedNames(): array
     {
-        $uniqueUsedNames = array_unique($this->usedNames);
-        sort($uniqueUsedNames);
+        return $this->usedNames;
+    }
 
-        return $uniqueUsedNames;
+    /**
+     * @return string[]
+     */
+    public function getUsedNamesInComments(): array
+    {
+        if ($this->comments === []) {
+            return [];
+        }
+
+        $tokens = $this->lexer->tokenize(implode(PHP_EOL, $this->comments));
+        $phpDocNode = $this->phpDocParser->parse(new TokenIterator($tokens));
+        $usedTypeNodeVisitor = new UsedTypeNodeVisitor();
+        $nodeTraverser = new \PHPStan\PhpDocParser\Ast\NodeTraverser([$usedTypeNodeVisitor]);
+        $nodeTraverser->traverse([$phpDocNode]);
+
+        $filteredTypes = array_diff($usedTypeNodeVisitor->getUsedTypes(), self::TYPES_TO_SKIP);
+
+        return array_unique($filteredTypes);
     }
 
     private function isNonNameNode(Name $name): bool

--- a/src/PhpDocNodeVisitor/UsedTypeNodeVisitor.php
+++ b/src/PhpDocNodeVisitor/UsedTypeNodeVisitor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\PhpDocNodeVisitor;
+
+use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+
+final class UsedTypeNodeVisitor extends AbstractNodeVisitor
+{
+    /**
+     * @var string[]
+     */
+    private array $usedTypes = [];
+
+    public function beforeTraverse(array $nodes): ?array
+    {
+        $this->usedTypes = [];
+        return null;
+    }
+
+    public function enterNode(Node $node)
+    {
+        if (! $node instanceof IdentifierTypeNode) {
+            return null;
+        }
+
+        $this->usedTypes[] = $node->name;
+
+        return null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getUsedTypes(): array
+    {
+        return $this->usedTypes;
+    }
+}

--- a/src/Reporting/UnusedClassReporter.php
+++ b/src/Reporting/UnusedClassReporter.php
@@ -12,15 +12,10 @@ use TomasVotruba\ClassLeak\ValueObject\UnusedClassesResult;
 
 final readonly class UnusedClassReporter
 {
-    public function __construct(
-        private SymfonyStyle $symfonyStyle
-    ) {
-    }
-
     /**
      * @return Command::*
      */
-    public function reportResult(UnusedClassesResult $unusedClassesResult, int $classCount, bool $isJson): int
+    public function reportResult(SymfonyStyle $symfonyStyle, UnusedClassesResult $unusedClassesResult, int $classCount, bool $isJson): int
     {
         if ($isJson) {
             $jsonResult = [
@@ -29,34 +24,34 @@ final readonly class UnusedClassReporter
                 'unused_classes_with_parents' => $unusedClassesResult->getWithParentsFileWithClasses(),
             ];
 
-            $this->symfonyStyle->writeln(Json::encode($jsonResult, Json::PRETTY));
+            $symfonyStyle->writeln(Json::encode($jsonResult, Json::PRETTY));
 
             return Command::SUCCESS;
         }
 
-        $this->symfonyStyle->newLine(2);
+        $symfonyStyle->newLine(2);
 
         if ($unusedClassesResult->getCount() === 0) {
-            $this->symfonyStyle->success(sprintf('All the %d services are used. Great job!', $classCount));
+            $symfonyStyle->success(sprintf('All the %d services are used. Great job!', $classCount));
             return Command::SUCCESS;
         }
 
         // separate with and without parent, as first one can be removed more easily
         if ($unusedClassesResult->getWithParentsFileWithClasses() !== []) {
-            $this->symfonyStyle->title('Classes with a parent/interface - possibly used by type');
+            $symfonyStyle->title('Classes with a parent/interface - possibly used by type');
 
-            $this->reportFileWithClasses($unusedClassesResult->getWithParentsFileWithClasses());
+            $this->reportFileWithClasses($symfonyStyle, $unusedClassesResult->getWithParentsFileWithClasses());
         }
 
         if ($unusedClassesResult->getParentLessFileWithClasses() !== []) {
-            $this->symfonyStyle->newLine();
-            $this->symfonyStyle->title('Classes without any parent/interface - easier to remove');
+            $symfonyStyle->newLine();
+            $symfonyStyle->title('Classes without any parent/interface - easier to remove');
 
-            $this->reportFileWithClasses($unusedClassesResult->getParentLessFileWithClasses());
+            $this->reportFileWithClasses($symfonyStyle, $unusedClassesResult->getParentLessFileWithClasses());
         }
 
-        $this->symfonyStyle->newLine();
-        $this->symfonyStyle->error(sprintf(
+        $symfonyStyle->newLine();
+        $symfonyStyle->error(sprintf(
             'Found %d unused classes. Check and remove them or skip them using "--skip-type" option',
             $unusedClassesResult->getCount()
         ));
@@ -67,12 +62,12 @@ final readonly class UnusedClassReporter
     /**
      * @param FileWithClass[] $fileWithClasses
      */
-    private function reportFileWithClasses(array $fileWithClasses): void
+    private function reportFileWithClasses(SymfonyStyle $symfonyStyle, array $fileWithClasses): void
     {
         foreach ($fileWithClasses as $fileWithClass) {
-            $this->symfonyStyle->writeln(' * ' . $fileWithClass->getClassName());
-            $this->symfonyStyle->writeln($fileWithClass->getFilePath());
-            $this->symfonyStyle->newLine();
+            $symfonyStyle->writeln(' * ' . $fileWithClass->getClassName());
+            $symfonyStyle->writeln($fileWithClass->getFilePath());
+            $symfonyStyle->newLine();
         }
     }
 }

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -7,13 +7,13 @@ namespace TomasVotruba\ClassLeak\ValueObject;
 final readonly class ClassNames
 {
     /**
-     * @param string[] $attributes
+     * @param string[] $usedAttributes
      */
     public function __construct(
         private string $className,
         private bool $hasParentClassOrInterface,
         private bool $hasApiTag,
-        private array $attributes,
+        private array $usedAttributes,
     ) {
     }
 
@@ -35,8 +35,8 @@ final readonly class ClassNames
     /**
      * @return string[]
      */
-    public function getAttributes(): array
+    public function getUsedAttributes(): array
     {
-        return $this->attributes;
+        return $this->usedAttributes;
     }
 }

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -12,6 +12,7 @@ final readonly class ClassNames
     public function __construct(
         private string $className,
         private bool $hasParentClassOrInterface,
+        private bool $hasApiTag,
         private array $attributes,
     ) {
     }
@@ -24,6 +25,11 @@ final readonly class ClassNames
     public function hasParentClassOrInterface(): bool
     {
         return $this->hasParentClassOrInterface;
+    }
+
+    public function hasApiTag() : bool
+    {
+        return $this->hasApiTag;
     }
 
     /**

--- a/src/ValueObject/ClassNames.php
+++ b/src/ValueObject/ClassNames.php
@@ -8,12 +8,14 @@ final readonly class ClassNames
 {
     /**
      * @param string[] $usedAttributes
+     * @param array<string, string> $imports
      */
     public function __construct(
         private string $className,
         private bool $hasParentClassOrInterface,
         private bool $hasApiTag,
         private array $usedAttributes,
+        private array $imports,
     ) {
     }
 
@@ -27,7 +29,7 @@ final readonly class ClassNames
         return $this->hasParentClassOrInterface;
     }
 
-    public function hasApiTag() : bool
+    public function hasApiTag(): bool
     {
         return $this->hasApiTag;
     }
@@ -38,5 +40,13 @@ final readonly class ClassNames
     public function getUsedAttributes(): array
     {
         return $this->usedAttributes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getImports(): array
+    {
+        return $this->imports;
     }
 }

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -9,8 +9,11 @@ use TomasVotruba\ClassLeak\FileSystem\StaticRelativeFilePathHelper;
 
 final readonly class FileWithClass implements JsonSerializable
 {
+    private ?string $namespace;
+
     /**
      * @param string[] $usedAttributes
+     * @param array<string, string> $imports
      */
     public function __construct(
         private string $filePath,
@@ -18,7 +21,10 @@ final readonly class FileWithClass implements JsonSerializable
         private bool $hasParentClassOrInterface,
         private bool $hasApiTag,
         private array $usedAttributes,
+        private array $imports,
     ) {
+        $pos = strrpos($this->className, '\\');
+        $this->namespace = $pos !== false ? substr($this->className, 0, $pos) : null;
     }
 
     public function getClassName(): string
@@ -49,23 +55,51 @@ final readonly class FileWithClass implements JsonSerializable
         return $this->usedAttributes;
     }
 
+    public function resolveName(string $name): string
+    {
+        if (str_starts_with($name, '\\')) {
+            return ltrim($name, '\\');
+        }
+
+        $nameParts = explode('\\', $name);
+        $firstNamePart = $nameParts[0];
+        if (isset($this->imports[$firstNamePart])) {
+            if (count($nameParts) === 1) {
+                return $this->imports[$firstNamePart];
+            }
+
+            array_shift($nameParts);
+
+            return sprintf('%s\\%s', $this->imports[$firstNamePart], implode('\\', $nameParts));
+        }
+
+        if ($this->namespace !== null) {
+            return sprintf('%s\\%s', $this->namespace, $name);
+        }
+
+        return $name;
+    }
+
     /**
      * @return array{
      *     file_path: string,
      *     class: string,
      *     has_parent_class_or_interface: bool,
      *     has_api_tag: bool,
-     *     used_attributes: string[]
+     *     used_attributes: string[],
+     *     imports: array<string, string>
      * }
      */
     public function jsonSerialize(): array
     {
         return [
             'file_path' => $this->filePath,
+            'namespace' => $this->namespace,
             'class' => $this->className,
             'has_parent_class_or_interface' => $this->hasParentClassOrInterface,
             'has_api_tag' => $this->hasApiTag,
             'used_attributes' => $this->usedAttributes,
+            'imports' => $this->imports,
         ];
     }
 }

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -16,6 +16,7 @@ final readonly class FileWithClass implements JsonSerializable
         private string $filePath,
         private string $className,
         private bool $hasParentClassOrInterface,
+        private bool $hasApiTag,
         private array $attributes,
     ) {
     }
@@ -35,6 +36,11 @@ final readonly class FileWithClass implements JsonSerializable
         return $this->hasParentClassOrInterface;
     }
 
+    public function hasApiTag(): bool
+    {
+        return $this->hasApiTag;
+    }
+
     /**
      * @return string[]
      */
@@ -44,13 +50,21 @@ final readonly class FileWithClass implements JsonSerializable
     }
 
     /**
-     * @return array{file_path: string, class: string, attributes: string[]}
+     * @return array{
+     *     file_path: string,
+     *     class: string,
+     *     has_parent_class_or_interface: bool,
+     *     has_api_tag: bool,
+     *     attributes: string[]
+     * }
      */
     public function jsonSerialize(): array
     {
         return [
             'file_path' => $this->filePath,
             'class' => $this->className,
+            'has_parent_class_or_interface' => $this->hasParentClassOrInterface,
+            'has_api_tag' => $this->hasApiTag,
             'attributes' => $this->attributes,
         ];
     }

--- a/src/ValueObject/FileWithClass.php
+++ b/src/ValueObject/FileWithClass.php
@@ -10,14 +10,14 @@ use TomasVotruba\ClassLeak\FileSystem\StaticRelativeFilePathHelper;
 final readonly class FileWithClass implements JsonSerializable
 {
     /**
-     * @param string[] $attributes
+     * @param string[] $usedAttributes
      */
     public function __construct(
         private string $filePath,
         private string $className,
         private bool $hasParentClassOrInterface,
         private bool $hasApiTag,
-        private array $attributes,
+        private array $usedAttributes,
     ) {
     }
 
@@ -44,9 +44,9 @@ final readonly class FileWithClass implements JsonSerializable
     /**
      * @return string[]
      */
-    public function getAttributes(): array
+    public function getUsedAttributes(): array
     {
-        return $this->attributes;
+        return $this->usedAttributes;
     }
 
     /**
@@ -55,7 +55,7 @@ final readonly class FileWithClass implements JsonSerializable
      *     class: string,
      *     has_parent_class_or_interface: bool,
      *     has_api_tag: bool,
-     *     attributes: string[]
+     *     used_attributes: string[]
      * }
      */
     public function jsonSerialize(): array
@@ -65,7 +65,7 @@ final readonly class FileWithClass implements JsonSerializable
             'class' => $this->className,
             'has_parent_class_or_interface' => $this->hasParentClassOrInterface,
             'has_api_tag' => $this->hasApiTag,
-            'attributes' => $this->attributes,
+            'used_attributes' => $this->usedAttributes,
         ];
     }
 }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -30,12 +30,7 @@ final class ClassNameResolverTest extends AbstractTestCase
         $resolvedClassNames = $this->classNameResolver->resolveFromFromFilePath($filePath);
         $this->assertInstanceOf(ClassNames::class, $resolvedClassNames);
 
-        $this->assertSame($expectedClassNames->getClassName(), $resolvedClassNames->getClassName());
-        $this->assertSame(
-            $expectedClassNames->hasParentClassOrInterface(),
-            $resolvedClassNames->hasParentClassOrInterface()
-        );
-        $this->assertSame($expectedClassNames->getAttributes(), $resolvedClassNames->getAttributes());
+        $this->assertEquals($expectedClassNames, $resolvedClassNames);
     }
 
     public static function provideData(): Iterator
@@ -45,6 +40,7 @@ final class ClassNameResolverTest extends AbstractTestCase
             new ClassNames(
                 SomeClass::class,
                 false,
+                true,
                 [SomeAttribute::class, SomeMethodAttribute::class],
             ),
         ];

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\ClassNameResolver;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\ClassWithOtherComment;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeClass;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeMethodAttribute;
@@ -42,6 +43,15 @@ final class ClassNameResolverTest extends AbstractTestCase
                 false,
                 true,
                 [SomeAttribute::class, SomeMethodAttribute::class],
+            ),
+        ];
+        yield [
+            __DIR__ . '/Fixture/ClassWithOtherComment.php',
+            new ClassNames(
+                ClassWithOtherComment::class,
+                false,
+                false,
+                [],
             ),
         ];
     }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver;
 
+use DateTime;
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\ClassNameResolver;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\Attributes\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\ClassWithOtherComment;
-use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeClass;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeMethodAttribute;
 use TomasVotruba\ClassLeak\ValueObject\ClassNames;
@@ -43,6 +44,10 @@ final class ClassNameResolverTest extends AbstractTestCase
                 false,
                 true,
                 [SomeAttribute::class, SomeMethodAttribute::class],
+                [
+                    'SomeAttribute' => SomeAttribute::class,
+                    'DateTime' => DateTime::class,
+                ],
             ),
         ];
         yield [
@@ -51,6 +56,7 @@ final class ClassNameResolverTest extends AbstractTestCase
                 ClassWithOtherComment::class,
                 false,
                 false,
+                [],
                 [],
             ),
         ];

--- a/tests/ClassNameResolver/Fixture/Attributes/SomeAttribute.php
+++ b/tests/ClassNameResolver/Fixture/Attributes/SomeAttribute.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\Attributes;
 
 use Attribute;
 

--- a/tests/ClassNameResolver/Fixture/ClassWithOtherComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithOtherComment.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+/**
+ * Some comment
+ */
+final readonly class ClassWithOtherComment
+{
+
+}

--- a/tests/ClassNameResolver/Fixture/SomeClass.php
+++ b/tests/ClassNameResolver/Fixture/SomeClass.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
+/**
+ * @api
+ */
 #[SomeAttribute]
 final class SomeClass
 {

--- a/tests/ClassNameResolver/Fixture/SomeClass.php
+++ b/tests/ClassNameResolver/Fixture/SomeClass.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
+use DateTime;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\Attributes\SomeAttribute;
+
 /**
  * @api
  */
@@ -11,7 +14,7 @@ namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 final class SomeClass
 {
     #[SomeMethodAttribute]
-    public function myMethod(): void
+    public function myMethod(): DateTime
     {
     }
 }

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\Filtering;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use TomasVotruba\ClassLeak\Filtering\PossiblyUnusedClassesFilter;
+use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
+
+final class PossiblyUnusedClassesFilterTest extends TestCase
+{
+    private PossiblyUnusedClassesFilter $filter;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->filter = new PossiblyUnusedClassesFilter();
+    }
+
+    /**
+     * @param FileWithClass[] $filesWithClasses
+     * @param string[] $usedClassNames
+     * @param string[] $typesToSkip
+     * @param string[] $suffixesToSkip
+     * @param string[] $attributesToSkip
+     */
+    #[DataProvider('provideData')]
+    public function test(
+        array $filesWithClasses,
+        array $usedClassNames,
+        array $typesToSkip,
+        array $suffixesToSkip,
+        array $attributesToSkip,
+        array $expectedFilteredFilesWithClasses,
+    ) : void {
+        self::assertEquals(
+            $expectedFilteredFilesWithClasses,
+            $this->filter->filter(
+                $filesWithClasses,
+                $usedClassNames,
+                $typesToSkip,
+                $suffixesToSkip,
+                $attributesToSkip,
+            ),
+        );
+    }
+
+    public static function provideData() : iterable
+    {
+        yield 'it should not filter' => [
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    false,
+                    [],
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    false,
+                    [],
+                ),
+            ],
+        ];
+
+        yield 'it should filter class with api tag' => [
+            [
+                new FileWithClass(
+                    'some-file.php',
+                    'SomeClass',
+                    false,
+                    true,
+                    [],
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
+        ];
+    }
+}

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -12,13 +12,13 @@ use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
 
 final class PossiblyUnusedClassesFilterTest extends TestCase
 {
-    private PossiblyUnusedClassesFilter $filter;
+    private PossiblyUnusedClassesFilter $possiblyUnusedClassesFilter;
 
     protected function setUp() : void
     {
         parent::setUp();
 
-        $this->filter = new PossiblyUnusedClassesFilter();
+        $this->possiblyUnusedClassesFilter = new PossiblyUnusedClassesFilter();
     }
 
     /**
@@ -27,6 +27,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
      * @param string[] $typesToSkip
      * @param string[] $suffixesToSkip
      * @param string[] $attributesToSkip
+     * @param FileWithClass[] $expectedFilteredFilesWithClasses
      */
     #[DataProvider('provideData')]
     public function test(
@@ -39,7 +40,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
     ) : void {
         self::assertEquals(
             $expectedFilteredFilesWithClasses,
-            $this->filter->filter(
+            $this->possiblyUnusedClassesFilter->filter(
                 $filesWithClasses,
                 $usedClassNames,
                 $typesToSkip,
@@ -49,6 +50,9 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
         );
     }
 
+    /**
+     * @return iterable<string, array{FileWithClass[], string[], string[], string[], string[], FileWithClass[]}>
+     */
     public static function provideData() : iterable
     {
         yield 'it should not filter' => [

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -62,6 +62,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
                     false,
                     false,
                     [],
+                    [],
                 ),
             ],
             [],
@@ -75,6 +76,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
                     false,
                     false,
                     [],
+                    [],
                 ),
             ],
         ];
@@ -86,6 +88,7 @@ final class PossiblyUnusedClassesFilterTest extends TestCase
                     'SomeClass',
                     false,
                     true,
+                    [],
                     [],
                 ),
             ],

--- a/tests/Filtering/PossiblyUnusedClassesFilterTest.php
+++ b/tests/Filtering/PossiblyUnusedClassesFilterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\Filtering;
 
-use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TomasVotruba\ClassLeak\Filtering\PossiblyUnusedClassesFilter;

--- a/tests/Functional/CheckCommandTest.php
+++ b/tests/Functional/CheckCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\Functional;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Tester\CommandTester;
+use TomasVotruba\ClassLeak\Commands\CheckCommand;
+use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\Functional\Fixture\Fixture1\MyResponse;
+
+final class CheckCommandTest extends AbstractTestCase
+{
+    private CheckCommand $checkCommand;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->checkCommand = $this->make(CheckCommand::class);
+    }
+
+    /**
+     * @param array<mixed> $expectedResult
+     */
+    #[DataProvider('provideData')]
+    public function test(string $path, array $expectedResult): void
+    {
+        $commandTester = new CommandTester($this->checkCommand);
+
+        $commandTester->execute([
+            'paths' => [$path],
+            '--json' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $json = $commandTester->getDisplay();
+
+        $this->assertJson($json);
+        $this->assertEquals($expectedResult, json_decode($json, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [
+            __DIR__ . '/Fixture/Fixture1',
+            [
+                'unused_class_count' => 1,
+                'unused_parent_less_classes' => [
+                    [
+                        'file_path' => __DIR__ . '/Fixture/Fixture1/MyResponse.php',
+                        'namespace' => 'TomasVotruba\\ClassLeak\\Tests\\Functional\\Fixture\\Fixture1',
+                        'class' => MyResponse::class,
+                        'has_parent_class_or_interface' => false,
+                        'has_api_tag' => false,
+                        'used_attributes' => [],
+                        'imports' => [],
+                    ],
+                ],
+                'unused_classes_with_parents' => [],
+            ],
+        ];
+    }
+}

--- a/tests/Functional/Fixture/Fixture1/MyResponse.php
+++ b/tests/Functional/Fixture/Fixture1/MyResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\Functional\Fixture\Fixture1;
+
+final readonly class MyResponse
+{
+    /**
+     * @param list<MyValue> $values
+     */
+    public function __construct(
+        public array $values,
+    ) {}
+}

--- a/tests/Functional/Fixture/Fixture1/MyValue.php
+++ b/tests/Functional/Fixture/Fixture1/MyValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\Functional\Fixture\Fixture1;
+
+final readonly class MyValue
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/UseImportsResolver/UseImportsResolverTest.php
+++ b/tests/UseImportsResolver/UseImportsResolverTest.php
@@ -12,6 +12,7 @@ use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\FirstUsedClass;
 use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\FourthUsedClass;
 use TomasVotruba\ClassLeak\Tests\UseImportsResolver\Source\SecondUsedClass;
 use TomasVotruba\ClassLeak\UseImportsResolver;
+use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
 
 final class UseImportsResolverTest extends AbstractTestCase
 {
@@ -28,15 +29,42 @@ final class UseImportsResolverTest extends AbstractTestCase
      * @param string[] $expectedClassUsages
      */
     #[DataProvider('provideData')]
-    public function test(string $filePath, array $expectedClassUsages): void
+    public function test(string $filePath, ?FileWithClass $fileWithClass, array $expectedClassUsages): void
     {
-        $resolvedClassUsages = $this->useImportsResolver->resolve($filePath);
+        $resolvedClassUsages = $this->useImportsResolver->resolve($filePath, $fileWithClass);
         $this->assertSame($expectedClassUsages, $resolvedClassUsages);
     }
 
     public static function provideData(): Iterator
     {
-        yield [__DIR__ . '/Fixture/FileUsingOtherClasses.php', [FirstUsedClass::class, SecondUsedClass::class]];
-        yield [__DIR__ . '/Fixture/FileUsesStaticCall.php', [SomeFactory::class, FourthUsedClass::class]];
+        yield [
+            __DIR__ . '/Fixture/FileUsingOtherClasses.php',
+            new FileWithClass(
+                __DIR__ . '/Fixture/FileUsingOtherClasses.php',
+                'FileUsingOtherClasses',
+                false,
+                false,
+                [],
+                [
+                    'FirstUsedClass' => FirstUsedClass::class,
+                    'SecondUsedClass' => SecondUsedClass::class,
+                ],
+            ),
+            [FirstUsedClass::class, SecondUsedClass::class]
+        ];
+        yield [
+            __DIR__ . '/Fixture/FileUsesStaticCall.php',
+            new FileWithClass(
+                __DIR__ . '/Fixture/FileUsesStaticCall.php',
+                'FileUsesStaticCall',
+                false,
+                false,
+                [],
+                [
+                    'FourthUsedClass' => FourthUsedClass::class,
+                ],
+            ),
+            [SomeFactory::class, FourthUsedClass::class]
+        ];
     }
 }


### PR DESCRIPTION
This depends on https://github.com/TomasVotruba/class-leak/pull/36

Fixes #35

Only the last 2 commits in this PR are new.

### Rename attributes to usedAttributes

This better explains that it's about used attributes.

### Search for used names in comments

By using PHPStan's PHPDoc parser, we can scan referenced types
inside PHPDocs.

Next to testing all the components separately, we introduce a functional
CheckCommandTest that runs the check command. Doing it this way, we make
sure that everything works together.

This also allows us to add more complex test cases too.
