### PR TITLE
Fix matching of `@api` class-comments

### DIFF
--- a/src/NodeVisitor/ClassNameNodeVisitor.php
+++ b/src/NodeVisitor/ClassNameNodeVisitor.php
@@ -119,8 +119,6 @@ final class ClassNameNodeVisitor extends NodeVisitorAbstract
             return false;
         }
 
-        preg_match(self::API_TAG_REGEX, $doc->getText(), $matches);
-
-        return $matches !== null;
+        return preg_match(self::API_TAG_REGEX, $doc->getText(), $matches) === 1;
     }
 }

--- a/tests/ClassNameResolver/ClassNameResolverTest.php
+++ b/tests/ClassNameResolver/ClassNameResolverTest.php
@@ -8,6 +8,8 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\ClassNameResolver;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\ClassWithAnyComment;
+use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\ClassWithApiComment;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeAttribute;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeClass;
 use TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture\SomeMethodAttribute;
@@ -25,11 +27,15 @@ final class ClassNameResolverTest extends AbstractTestCase
     }
 
     #[DataProvider('provideData')]
-    public function test(string $filePath, ClassNames $expectedClassNames): void
+    public function test(string $filePath, ?ClassNames $expectedClassNames): void
     {
         $resolvedClassNames = $this->classNameResolver->resolveFromFromFilePath($filePath);
-        $this->assertInstanceOf(ClassNames::class, $resolvedClassNames);
+        if ($expectedClassNames === null) {
+            $this->assertNull($resolvedClassNames);
+            return;
+        }
 
+        $this->assertInstanceOf(ClassNames::class, $resolvedClassNames);
         $this->assertSame($expectedClassNames->getClassName(), $resolvedClassNames->getClassName());
         $this->assertSame(
             $expectedClassNames->hasParentClassOrInterface(),
@@ -47,6 +53,20 @@ final class ClassNameResolverTest extends AbstractTestCase
                 false,
                 [SomeAttribute::class, SomeMethodAttribute::class],
             ),
+        ];
+
+        yield [
+            __DIR__ . '/Fixture/ClassWithAnyComment.php',
+            new ClassNames(
+                ClassWithAnyComment::class,
+                false,
+                [],
+            ),
+        ];
+
+        yield [
+            __DIR__ . '/Fixture/ClassWithApiComment.php',
+            null,
         ];
     }
 }

--- a/tests/ClassNameResolver/Fixture/ClassWithAnyComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithAnyComment.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+/** some comment */
+final class ClassWithAnyComment
+{
+}

--- a/tests/ClassNameResolver/Fixture/ClassWithApiComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithApiComment.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
+
+/** @api */
+final class ClassWithApiComment
+{
+}


### PR DESCRIPTION
before this PR, any class with just a comment - no matter what content this comment had - was handled like a `@api` commented class