### PR TITLE
Provide better error message after syntax error

### DIFF
--- a/src/UseImportsResolver.php
+++ b/src/UseImportsResolver.php
@@ -28,9 +28,13 @@ final readonly class UseImportsResolver
         /** @var string $fileContents */
         $fileContents = file_get_contents($filePath);
 
-        $stmts = $this->parser->parse($fileContents);
-        if ($stmts === null) {
-            return [];
+        try {
+            $stmts = $this->parser->parse($fileContents);
+            if ($stmts === null) {
+                return [];
+            }
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(sprintf('Could not parse file "%s": %s', $filePath, $e->getMessage()));
         }
 
         $this->fullyQualifiedNameNodeDecorator->decorate($stmts);

--- a/src/UseImportsResolver.php
+++ b/src/UseImportsResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak;
 
+use Throwable;
+use RuntimeException;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use TomasVotruba\ClassLeak\NodeDecorator\FullyQualifiedNameNodeDecorator;
@@ -33,8 +35,8 @@ final readonly class UseImportsResolver
             if ($stmts === null) {
                 return [];
             }
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(sprintf('Could not parse file "%s": %s', $filePath, $e->getMessage()));
+        } catch (Throwable $throwable) {
+            throw new RuntimeException(sprintf('Could not parse file "%s": %s', $filePath, $throwable->getMessage()), $throwable->getCode(), $throwable);
         }
 
         $this->fullyQualifiedNameNodeDecorator->decorate($stmts);

--- a/tests/UseImportsResolver/Fixture/ParseError.php
+++ b/tests/UseImportsResolver/Fixture/ParseError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ParseError;
+
+function doFoo() {
+    // this file intentionally contains this parse error
+    $x ABC
+}

--- a/tests/UseImportsResolver/UseImportsResolverTest.php
+++ b/tests/UseImportsResolver/UseImportsResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\UseImportsResolver;
 
+use RuntimeException;
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\ClassLeak\Tests\AbstractTestCase;
@@ -40,10 +41,13 @@ final class UseImportsResolverTest extends AbstractTestCase
         yield [__DIR__ . '/Fixture/FileUsesStaticCall.php', [SomeFactory::class, FourthUsedClass::class]];
     }
 
-    public function testParseError() {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Could not parse file "' . __DIR__ . '/Fixture/ParseError.php": Syntax error, unexpected T_STRING on line 7');
+    public function testParseError(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Could not parse file "' . __DIR__ . '/Fixture/ParseError.php": Syntax error, unexpected T_STRING on line 7'
+        );
 
-        $this->useImportsResolver->resolve(__DIR__ .'/Fixture/ParseError.php');
+        $this->useImportsResolver->resolve(__DIR__ . '/Fixture/ParseError.php');
     }
 }

--- a/tests/UseImportsResolver/UseImportsResolverTest.php
+++ b/tests/UseImportsResolver/UseImportsResolverTest.php
@@ -39,4 +39,11 @@ final class UseImportsResolverTest extends AbstractTestCase
         yield [__DIR__ . '/Fixture/FileUsingOtherClasses.php', [FirstUsedClass::class, SecondUsedClass::class]];
         yield [__DIR__ . '/Fixture/FileUsesStaticCall.php', [SomeFactory::class, FourthUsedClass::class]];
     }
+
+    public function testParseError() {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not parse file "' . __DIR__ . '/Fixture/ParseError.php": Syntax error, unexpected T_STRING on line 7');
+
+        $this->useImportsResolver->resolve(__DIR__ .'/Fixture/ParseError.php');
+    }
 }


### PR DESCRIPTION
After this PR we get a better error message, which contains a reference to the filename.

Before this PR
```
$ /c/tools/php83/php vendor/bin/class-leak.php check src tests 
    0/1840 [>---------------------------]   0%
  920/1840 [==============>-------------]  50%
In ParserAbstract.php line 272:
                                                          
  Syntax error, unexpected '{', expecting ';' on line 14  
                                                          

check [--skip-type SKIP-TYPE] [--skip-suffix SKIP-SUFFIX] [--skip-attribute SKIP-ATTRIBUTE] [--file-extension FILE-EXTENSION] [--json] [--] <paths>...
```

After this PR
```
$ /c/tools/php83/php vendor/bin/class-leak.php check src tests 
    0/1840 [>---------------------------]   0%
  920/1840 [==============>-------------]  50%
In ParserAbstract.php line 272:
                                                          
  Could not parse file "C:\dvl\Workspace\phpunit\tests\_files\mock-object\ExtendableClassWithPropertyWithGetHook.php": Syntax error, unexpected '{', expecting ';' on line 14  
                                                          

check [--skip-type SKIP-TYPE] [--skip-suffix SKIP-SUFFIX] [--skip-attribute SKIP-ATTRIBUTE] [--file-extension FILE-EXTENSION] [--json] [--] <paths>...
```

refs https://github.com/TomasVotruba/class-leak/issues/45