### PR TITLE
Add --skip-path option to skip directories by name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.2",
-        "phpstan/phpstan": "^1.10.57",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",
-        "rector/rector": "^1.0",
+        "rector/rector": "^1.2",
         "symplify/easy-coding-standard": "^12.1",
         "symplify/phpstan-extensions": "^11.2",
-        "tomasvotruba/unused-public": "^0.2",
+        "tomasvotruba/unused-public": "^1.0",
         "tracy/tracy": "^2.10"
     },
     "autoload": {

--- a/ecs.php
+++ b/ecs.php
@@ -6,6 +6,7 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
     ->withPaths([
+        __DIR__ . '/bin',
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])

--- a/rector.php
+++ b/rector.php
@@ -10,9 +10,9 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPreparedSets(
-        deadCode: true, naming: true, privatization: true, earlyReturn: true, codeQuality: true, codingStyle: true, typeDeclarations: true
+        deadCode: true, naming: true, privatization: true, earlyReturn: true, codeQuality: true, codingStyle: true, typeDeclarations: true, phpunit: true, phpunitCodeQuality: true
     )
     ->withPhpSets()
     ->withRootFiles()
-    ->withImportNames(removeUnusedImports: true)
+    ->withImportNames()
     ->withSkip(['*/scoper.php', '*/Source/*', '*/Fixture/*']);

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -57,6 +57,13 @@ final class CheckCommand extends Command
         );
 
         $this->addOption(
+            'skip-path',
+            null,
+            InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+            'Paths to skip (real path or just directory name)'
+        );
+
+        $this->addOption(
             'skip-attribute',
             null,
             InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
@@ -88,12 +95,15 @@ final class CheckCommand extends Command
         /** @var string[] $attributesToSkip */
         $attributesToSkip = (array) $input->getOption('skip-attribute');
 
+        /** @var string[] $pathsToSkip */
+        $pathsToSkip = (array) $input->getOption('skip-path');
+
         $isJson = (bool) $input->getOption('json');
 
         /** @var string[] $fileExtensions */
         $fileExtensions = (array) $input->getOption('file-extension');
 
-        $phpFilePaths = $this->phpFilesFinder->findPhpFiles($paths, $fileExtensions);
+        $phpFilePaths = $this->phpFilesFinder->findPhpFiles($paths, $fileExtensions, $pathsToSkip);
 
         if (! $isJson) {
             $this->symfonyStyle->progressStart(count($phpFilePaths));

--- a/src/Finder/PhpFilesFinder.php
+++ b/src/Finder/PhpFilesFinder.php
@@ -16,9 +16,11 @@ final class PhpFilesFinder
     /**
      * @param string[] $paths
      * @param string[] $fileExtensions
+     * @param string[] $pathsToSkip
+     *
      * @return string[]
      */
-    public function findPhpFiles(array $paths, array $fileExtensions): array
+    public function findPhpFiles(array $paths, array $fileExtensions, array $pathsToSkip): array
     {
         Assert::allFileExists($paths);
         Assert::allString($fileExtensions);
@@ -29,6 +31,10 @@ final class PhpFilesFinder
         $currentFileFinder = Finder::create()->files()
             ->in($paths)
             ->sortByName();
+
+        if ($pathsToSkip !== []) {
+            $currentFileFinder->exclude($pathsToSkip);
+        }
 
         foreach ($fileExtensions as $fileExtension) {
             $currentFileFinder->name('*.' . $fileExtension);

--- a/tests/Finder/PhpFilesFinderTest.php
+++ b/tests/Finder/PhpFilesFinderTest.php
@@ -20,10 +20,10 @@ final class PhpFilesFinderTest extends AbstractTestCase
 
     public function test(): void
     {
-        $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php', 'phtml']);
+        $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php', 'phtml'], []);
         $this->assertCount(4, $phpFiles);
 
-        $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php']);
+        $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php'], []);
         $this->assertCount(3, $phpFiles);
     }
 }


### PR DESCRIPTION
Do you want to skip all fixture, dummy, sources file from being reported unused?

Now you can :) :partying_face: 

```bash
vendor/bin/class-leak check src tests --ansi --skip-path=Fixture --skip-path=Source
```
