### PR TITLE
fix: Skipping paths doesn't seem to work (fixes TomasVotruba/class-leak#59)

### DIFF
--- a/src/Filtering/PossiblyUnusedClassesFilter.php
+++ b/src/Filtering/PossiblyUnusedClassesFilter.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Filtering;
 
+use Illuminate\Contracts\Http\Kernel;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
+use PHPStan\Rules\Rule;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use TomasVotruba\ClassLeak\ValueObject\FileWithClass;
 use Webmozart\Assert\Assert;
 
@@ -17,13 +24,13 @@ final readonly class PossiblyUnusedClassesFilter
      */
     private const DEFAULT_TYPES_TO_SKIP = [
         // http-kernel
-        'Symfony\Component\Console\Application',
+        Application::class,
         'Symfony\Component\HttpKernel\DependencyInjection\Extension',
         'Symfony\Bundle\FrameworkBundle\Controller\Controller',
         'Symfony\Bundle\FrameworkBundle\Controller\AbstractController',
         'Livewire\Component',
         'Illuminate\Routing\Controller',
-        'Illuminate\Contracts\Http\Kernel',
+        Kernel::class,
         'Illuminate\Support\ServiceProvider',
         // events
         'Symfony\Component\EventDispatcher\EventSubscriberInterface',
@@ -54,12 +61,12 @@ final readonly class PossiblyUnusedClassesFilter
         'Symfony\Component\HttpKernel\KernelInterface',
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
         // console
-        'Symfony\Component\Console\Command\Command',
+        Command::class,
         'Twig\Extension\ExtensionInterface',
         'PhpCsFixer\Fixer\FixerInterface',
-        'PHPUnit\Framework\TestCase',
-        'PHPStan\Rules\Rule',
-        'PHPStan\Command\ErrorFormatter\ErrorFormatter',
+        TestCase::class,
+        Rule::class,
+        ErrorFormatter::class,
         // tests
         'Behat\Behat\Context\Context',
         // jms
@@ -67,7 +74,7 @@ final readonly class PossiblyUnusedClassesFilter
         // laravel
         'Illuminate\Support\ServiceProvider',
         'Illuminate\Foundation\Http\Kernel',
-        'Illuminate\Contracts\Console\Kernel',
+        \Illuminate\Contracts\Console\Kernel::class,
         'Illuminate\Routing\Controller',
         // Doctrine
         'Doctrine\Migrations\AbstractMigration',
@@ -78,7 +85,7 @@ final readonly class PossiblyUnusedClassesFilter
      */
     private const DEFAULT_ATTRIBUTES_TO_SKIP = [
         // Symfony
-        'Symfony\Component\Console\Attribute\AsCommand',
+        AsCommand::class,
         'Symfony\Component\HttpKernel\Attribute\AsController',
         'Symfony\Component\EventDispatcher\Attribute\AsEventListener',
     ];

--- a/src/Finder/PhpFilesFinder.php
+++ b/src/Finder/PhpFilesFinder.php
@@ -25,6 +25,25 @@ final class PhpFilesFinder
         Assert::allFileExists($paths);
         Assert::allString($fileExtensions);
 
+        // skip-path option supports both directory names (e.g. "vendor") and
+        // real/relative paths (e.g. "lib/vendor"). Symfony Finder's exclude()
+        // matches relative paths from each searched root, so paths that include
+        // the searched root prefix never match. Split them: pass simple
+        // directory names to exclude(), and post-filter the rest by realpath.
+        $excludedDirectoryNames = [];
+        $excludedRealPaths = [];
+        foreach ($pathsToSkip as $pathToSkip) {
+            if (! str_contains($pathToSkip, '/') && ! str_contains($pathToSkip, '\\')) {
+                $excludedDirectoryNames[] = $pathToSkip;
+                continue;
+            }
+
+            $realPath = realpath($pathToSkip);
+            if ($realPath !== false) {
+                $excludedRealPaths[] = $realPath;
+            }
+        }
+
         // fallback to config paths
         $filePaths = [];
 
@@ -32,8 +51,8 @@ final class PhpFilesFinder
             ->in($paths)
             ->sortByName();
 
-        if ($pathsToSkip !== []) {
-            $currentFileFinder->exclude($pathsToSkip);
+        if ($excludedDirectoryNames !== []) {
+            $currentFileFinder->exclude($excludedDirectoryNames);
         }
 
         foreach ($fileExtensions as $fileExtension) {
@@ -42,9 +61,33 @@ final class PhpFilesFinder
 
         foreach ($currentFileFinder as $fileInfo) {
             /** @var SplFileInfo $fileInfo */
-            $filePaths[] = $fileInfo->getRealPath();
+            $realPath = $fileInfo->getRealPath();
+
+            if ($this->isWithinExcludedPath($realPath, $excludedRealPaths)) {
+                continue;
+            }
+
+            $filePaths[] = $realPath;
         }
 
         return $filePaths;
+    }
+
+    /**
+     * @param string[] $excludedRealPaths
+     */
+    private function isWithinExcludedPath(string $realPath, array $excludedRealPaths): bool
+    {
+        foreach ($excludedRealPaths as $excludedRealPath) {
+            if ($realPath === $excludedRealPath) {
+                return true;
+            }
+
+            if (str_starts_with($realPath, $excludedRealPath . DIRECTORY_SEPARATOR)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/ClassNameResolver/Fixture/ClassWithAnyComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithAnyComment.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
-/** some comment */
+/**
+ * some comment
+ */
 final class ClassWithAnyComment
 {
 }

--- a/tests/ClassNameResolver/Fixture/ClassWithApiComment.php
+++ b/tests/ClassNameResolver/Fixture/ClassWithApiComment.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\ClassLeak\Tests\ClassNameResolver\Fixture;
 
-/** @api */
+/**
+ * @api
+ */
 final class ClassWithApiComment
 {
 }

--- a/tests/Finder/PhpFilesFinderTest.php
+++ b/tests/Finder/PhpFilesFinderTest.php
@@ -26,4 +26,20 @@ final class PhpFilesFinderTest extends AbstractTestCase
         $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php'], []);
         $this->assertCount(3, $phpFiles);
     }
+
+    public function testSkipPathByDirectoryName(): void
+    {
+        $phpFiles = $this->phpFilesFinder->findPhpFiles([__DIR__ . '/Fixture'], ['php'], ['more-nested']);
+        $this->assertCount(2, $phpFiles);
+    }
+
+    public function testSkipPathByRelativePath(): void
+    {
+        $phpFiles = $this->phpFilesFinder->findPhpFiles(
+            [__DIR__ . '/Fixture'],
+            ['php'],
+            [__DIR__ . '/Fixture/some/more-nested']
+        );
+        $this->assertCount(2, $phpFiles);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes TomasVotruba/class-leak#59 — Skipping paths doesn't seem to work

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.