### PR TITLE
allow entropy ^0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=8.4",
-        "entropy/entropy": "^0.3",
+        "entropy/entropy": "^0.3 || ^0.4",
         "nette/utils": "^4.1",
         "nikic/php-parser": "^5.7",
         "symfony/finder": "^7.4|^8.0",


### PR DESCRIPTION
entropy 0.4.0 keeps the Container + Console API class-leak uses, so widen
the constraint to ^0.3 || ^0.4 to unblock downstream upgrades (ECS).
